### PR TITLE
refactor: smooth graph nodes and panel layout

### DIFF
--- a/web/src/components/graph/ControlPanel.tsx
+++ b/web/src/components/graph/ControlPanel.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import {Button, Stack, Popover, IconButton, Tooltip, Box, Drawer} from '@mui/material'
+import {Button, Stack, IconButton, Tooltip, Box, Drawer} from '@mui/material'
 import SettingsIcon from '@mui/icons-material/Settings'
 import { useState } from 'react'
 import {useMediaQuery, useTheme} from "@mui/system";
 import {MenuIcon} from "lucide-react";
-import ExpandConfigPanel from "./ExpandConfigPanel";
 import ConfigDrawer from "./ConfigDrawer";
 import {simulateAutoExpand} from "@/src/lib/simulateAutoExpand";
 import {GrowMode} from "@/src/types/GrowthNode";
@@ -46,11 +45,6 @@ export default function ControlPanel() {
         setGrowMode(nextMode)
     }
 
-    // Popover 控制
-    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-    const handleCloseConfig = () => setAnchorEl(null)
-    const openPopover = Boolean(anchorEl)
-
     // Drawer 控制
     const [drawerOpen, setDrawerOpen] = useState(false)
 
@@ -73,38 +67,39 @@ export default function ControlPanel() {
 
                         <Drawer anchor="right" open={menuOpen} onClose={() => setMenuOpen(false)}>
                             <Box sx={{ width: 260, p: 2 }}>
-                                <Button variant="contained" fullWidth onClick={handleAdd} sx={{ mb: 1 }}>
-                                    ➕ 添加节点
-                                </Button>
-                                <Button variant="outlined" fullWidth color="error" onClick={reset} sx={{ mb: 1 }}>
-                                    🗑️ 清空画布
-                                </Button>
-                                <Button
-                                    variant="contained"
-                                    color="secondary"
-                                    fullWidth
-                                    onClick={handleAutoGrow}
-                                    disabled={growMode === 'manual'}
-                                    sx={{ mb: 1 }}
-                                >
-                                    自动扩展（{modeNameMap[growMode]}）
-                                </Button>
-                                <Button variant="text" fullWidth onClick={handleToggleMode} sx={{ mb: 1 }}>
-                                    切换为{' '}
-                                    {modeNameMap[
-                                        growMode === 'manual' ? 'free' : growMode === 'free' ? 'fury' : 'manual'
-                                        ]}
-                                </Button>
-                                <Button
-                                    startIcon={<SettingsIcon />}
-                                    onClick={() => {
-                                        setDrawerOpen(true)
-                                        setMenuOpen(false)
-                                    }}
-                                    fullWidth
-                                >
-                                    打开高级配置
-                                </Button>
+                                <Stack spacing={1}>
+                                    <Button variant="contained" fullWidth onClick={handleAdd}>
+                                        ➕ 添加节点
+                                    </Button>
+                                    <Button variant="outlined" fullWidth color="error" onClick={reset}>
+                                        🗑️ 清空画布
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        color="secondary"
+                                        fullWidth
+                                        onClick={handleAutoGrow}
+                                        disabled={growMode === 'manual'}
+                                    >
+                                        自动扩展（{modeNameMap[growMode]}）
+                                    </Button>
+                                    <Button variant="text" fullWidth onClick={handleToggleMode}>
+                                        切换为{' '}
+                                        {modeNameMap[
+                                            growMode === 'manual' ? 'free' : growMode === 'free' ? 'fury' : 'manual'
+                                            ]}
+                                    </Button>
+                                    <Button
+                                        startIcon={<SettingsIcon />}
+                                        onClick={() => {
+                                            setDrawerOpen(true)
+                                            setMenuOpen(false)
+                                        }}
+                                        fullWidth
+                                    >
+                                        打开高级配置
+                                    </Button>
+                                </Stack>
                             </Box>
                         </Drawer>
                     </>
@@ -114,7 +109,7 @@ export default function ControlPanel() {
                         spacing={2}
                         alignItems="center"
                         justifyContent="center"
-                        sx={{ mb: 2 }}
+                        sx={{ mb: 2, flexWrap: 'wrap' }}
                     >
                         <Button variant="contained" onClick={handleAdd}>
                             添加节点
@@ -145,23 +140,6 @@ export default function ControlPanel() {
                 )}
 
 
-
-                <Popover
-                    open={openPopover}
-                    anchorEl={anchorEl}
-                    onClose={handleCloseConfig}
-                    anchorOrigin={{
-                        vertical: 'bottom',
-                        horizontal: 'left',
-                    }}
-                    slotProps={{
-                        paper: {
-                            sx: { mt: 1, p: 1, borderRadius: 2, minWidth: 360 },
-                        },
-                    }}
-                >
-                    <ExpandConfigPanel />
-                </Popover>
 
                 <ConfigDrawer open={drawerOpen} closeAction={() => setDrawerOpen(false)} />
             </>

--- a/web/src/components/graph/NodeRenderer.tsx
+++ b/web/src/components/graph/NodeRenderer.tsx
@@ -4,9 +4,11 @@ import { motion } from 'framer-motion'
 export default function NodeRenderer({ data }: NodeProps) {
     return (
         <motion.div
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
+            layout
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
             whileHover={{ scale: 1.05 }}
+            transition={{ type: 'spring', stiffness: 260, damping: 20 }}
             className="p-4 rounded-lg shadow-lg border bg-white text-center"
             style={{ borderColor: data.color, borderWidth: 2 }}
         >

--- a/web/src/lib/simulateAutoExpand.ts
+++ b/web/src/lib/simulateAutoExpand.ts
@@ -18,43 +18,32 @@ function generateChildNodes(
     parent: Node,
     count: number,
     radius: number,
-    angleSpread: number,
+    angleOffset: number,
     existingNodes: Node[]
 ): Node[] {
-    const angleStep = angleSpread / count
+    const goldenAngle = (Math.PI * (3 - Math.sqrt(5))) // ~137.5°
     const generated: Node[] = []
 
     for (let i = 0; i < count; i++) {
-        let attempt = 0
-        let x = 0, y = 0
-        let valid = false
+        const angle = angleOffset + i * goldenAngle
+        const offset = radius + i * 25
 
-        while (!valid && attempt < 10) {
-            const angleDeg = -angleSpread / 2 + angleStep * i + (Math.random() - 0.5) * 10
-            const angle = (angleDeg * Math.PI) / 180
-            const offset = radius + (Math.random() - 0.5) * 60
+        const x = parent.position.x + Math.cos(angle) * offset
+        const y = parent.position.y + Math.sin(angle) * offset
 
-            x = parent.position.x + Math.cos(angle) * offset
-            y = parent.position.y + Math.sin(angle) * offset
-
-            valid = [...existingNodes, ...generated].every(
-                (n) => !isTooClose(n.position, { x, y })
-            )
-
-            attempt++
+        if ([...existingNodes, ...generated].every((n) => !isTooClose(n.position, { x, y }))) {
+            generated.push({
+                id: nanoid(),
+                type: 'thought',
+                position: { x, y },
+                data: {
+                    title: '扩展想法',
+                    summary: '自动扩展节点',
+                    tags: ['自动'],
+                    highlight: false,
+                },
+            })
         }
-
-        generated.push({
-            id: nanoid(),
-            type: 'thought',
-            position: { x, y },
-            data: {
-                title: '扩展想法',
-                summary: '自动扩展节点',
-                tags: ['自动'],
-                highlight: false,
-            },
-        })
     }
 
     return generated


### PR DESCRIPTION
## Summary
- smooth node rendering with animated spring transition
- improve auto-expansion using golden-angle layout
- reorganize control panel with responsive stack and drawer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint configuration, unable to proceed)


------
https://chatgpt.com/codex/tasks/task_e_6898345c915c832ebb25468d7f0c17e3