### PR TITLE
feat: add prompt dialog and service selectors in graph control panel

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from api.routers import seed, services, tests, text
 from api.utils.lifespan import lifespan
 
 app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(seed.router)
 app.include_router(services.router)

--- a/web/components/graph/ControlPanel.tsx
+++ b/web/components/graph/ControlPanel.tsx
@@ -1,49 +1,35 @@
 'use client'
 
-import {Button, Stack, IconButton, Tooltip, Box, Drawer} from '@mui/material'
+import {
+    Button,
+    Stack,
+    IconButton,
+    Tooltip,
+    Box,
+    Drawer,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+} from '@mui/material'
 import SettingsIcon from '@mui/icons-material/Settings'
 import { useState } from 'react'
 import {useMediaQuery, useTheme} from "@mui/system";
 import {MenuIcon} from "lucide-react";
 import ConfigDrawer from "./ConfigDrawer";
-import {simulateAutoExpand} from "@/lib/simulateAutoExpand";
-import {GrowMode} from "@/types/GrowthNode";
 import {useGraphStore} from "@/lib/graphStore";
-import {createThoughtNode} from "@/lib/nodeUtils";
-
-const modeNameMap = {
-    manual: '手动模式',
-    free: '自由模式',
-    fury: '狂暴模式',
-}
+import PromptDialog from "./PromptDialog";
 
 export default function ControlPanel() {
     const theme = useTheme()
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
     const [menuOpen, setMenuOpen] = useState(false)
 
-    const { addNode, reset, growMode, setGrowMode, nodes } = useGraphStore()
+    const { reset } = useGraphStore()
 
-    const handleAdd = () => {
-        const node = createThoughtNode(Math.random() * 600, Math.random() * 400, {
-            title: '手动节点',
-            description: '用户手动添加',
-            node_metadata: { tags: ['手动'] },
-            color: '#4ade80',
-        })
-        addNode(node)
-    }
-
-    const handleAutoGrow = () => {
-        const root = nodes.find((n) => n.id === 'root')
-        if (root) simulateAutoExpand(root.id)
-    }
-
-    const handleToggleMode = () => {
-        const nextMode: GrowMode =
-            growMode === 'manual' ? 'free' : growMode === 'free' ? 'fury' : 'manual'
-        setGrowMode(nextMode)
-    }
+    const [promptOpen, setPromptOpen] = useState(false)
+    const [gptService, setGptService] = useState('default')
+    const [gnnService, setGnnService] = useState('default')
 
     // Drawer 控制
     const [drawerOpen, setDrawerOpen] = useState(false)
@@ -68,26 +54,33 @@ export default function ControlPanel() {
                         <Drawer anchor="right" open={menuOpen} onClose={() => setMenuOpen(false)}>
                             <Box sx={{ width: 260, p: 2 }}>
                                 <Stack spacing={1}>
-                                    <Button variant="contained" fullWidth onClick={handleAdd}>
-                                        ➕ 添加节点
+                                    <FormControl fullWidth>
+                                        <InputLabel>GPT 服务</InputLabel>
+                                        <Select
+                                            value={gptService}
+                                            label="GPT 服务"
+                                            onChange={(e) => setGptService(e.target.value)}
+                                        >
+                                            <MenuItem value="default">默认</MenuItem>
+                                            <MenuItem value="gpt-4">GPT-4</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                    <FormControl fullWidth>
+                                        <InputLabel>GNN 服务</InputLabel>
+                                        <Select
+                                            value={gnnService}
+                                            label="GNN 服务"
+                                            onChange={(e) => setGnnService(e.target.value)}
+                                        >
+                                            <MenuItem value="default">默认</MenuItem>
+                                            <MenuItem value="gnn-advanced">高级</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                    <Button variant="contained" fullWidth onClick={() => setPromptOpen(true)}>
+                                        打开提示词
                                     </Button>
                                     <Button variant="outlined" fullWidth color="error" onClick={reset}>
                                         🗑️ 清空画布
-                                    </Button>
-                                    <Button
-                                        variant="contained"
-                                        color="secondary"
-                                        fullWidth
-                                        onClick={handleAutoGrow}
-                                        disabled={growMode === 'manual'}
-                                    >
-                                        自动扩展（{modeNameMap[growMode]}）
-                                    </Button>
-                                    <Button variant="text" fullWidth onClick={handleToggleMode}>
-                                        切换为{' '}
-                                        {modeNameMap[
-                                            growMode === 'manual' ? 'free' : growMode === 'free' ? 'fury' : 'manual'
-                                            ]}
                                     </Button>
                                     <Button
                                         startIcon={<SettingsIcon />}
@@ -111,25 +104,33 @@ export default function ControlPanel() {
                         justifyContent="center"
                         sx={{ mb: 2, flexWrap: 'wrap' }}
                     >
-                        <Button variant="contained" onClick={handleAdd}>
-                            添加节点
+                        <FormControl sx={{ minWidth: 120 }} size="small">
+                            <InputLabel>GPT 服务</InputLabel>
+                            <Select
+                                value={gptService}
+                                label="GPT 服务"
+                                onChange={(e) => setGptService(e.target.value)}
+                            >
+                                <MenuItem value="default">默认</MenuItem>
+                                <MenuItem value="gpt-4">GPT-4</MenuItem>
+                            </Select>
+                        </FormControl>
+                        <FormControl sx={{ minWidth: 120 }} size="small">
+                            <InputLabel>GNN 服务</InputLabel>
+                            <Select
+                                value={gnnService}
+                                label="GNN 服务"
+                                onChange={(e) => setGnnService(e.target.value)}
+                            >
+                                <MenuItem value="default">默认</MenuItem>
+                                <MenuItem value="gnn-advanced">高级</MenuItem>
+                            </Select>
+                        </FormControl>
+                        <Button variant="contained" onClick={() => setPromptOpen(true)}>
+                            打开提示词
                         </Button>
                         <Button variant="outlined" color="error" onClick={reset}>
                             清空画布
-                        </Button>
-                        <Button
-                            variant="contained"
-                            color="secondary"
-                            onClick={handleAutoGrow}
-                            disabled={growMode === 'manual'}
-                        >
-                            自动扩展（{modeNameMap[growMode]}）
-                        </Button>
-                        <Button variant="text" onClick={handleToggleMode}>
-                            切换为{' '}
-                            {modeNameMap[
-                                growMode === 'manual' ? 'free' : growMode === 'free' ? 'fury' : 'manual'
-                                ]}
                         </Button>
                         <Tooltip title="打开高级配置">
                             <IconButton onClick={() => setDrawerOpen(true)}>
@@ -139,8 +140,7 @@ export default function ControlPanel() {
                     </Stack>
                 )}
 
-
-
+                <PromptDialog open={promptOpen} onClose={() => setPromptOpen(false)} />
                 <ConfigDrawer open={drawerOpen} closeAction={() => setDrawerOpen(false)} />
             </>
         </Box>

--- a/web/components/graph/PromptDialog.tsx
+++ b/web/components/graph/PromptDialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    TextField,
+    Button,
+    Stack,
+} from '@mui/material'
+import { useSeedApi } from '@/hooks/useSeed'
+
+interface PromptDialogProps {
+    open: boolean
+    onClose: () => void
+}
+
+export default function PromptDialog({ open, onClose }: PromptDialogProps) {
+    const { createSeed, expandSeed } = useSeedApi()
+    const [seedId, setSeedId] = useState<number | null>(null)
+    const [title, setTitle] = useState('')
+    const [prompt, setPrompt] = useState('')
+
+    const handleCreateSeed = async () => {
+        try {
+            const seed = await createSeed({ title })
+            setSeedId(seed.id)
+        } catch (error) {
+            console.error('创建种子失败', error)
+        }
+    }
+
+    const handleExpand = async () => {
+        if (seedId == null) return
+        try {
+            await expandSeed(seedId, { prompt })
+        } catch (error) {
+            console.error('扩展种子失败', error)
+        }
+    }
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth>
+            <DialogTitle>提示词配置</DialogTitle>
+            <DialogContent>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                    <TextField
+                        label="种子标题"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        fullWidth
+                    />
+                    <TextField
+                        label="提示词"
+                        value={prompt}
+                        onChange={(e) => setPrompt(e.target.value)}
+                        fullWidth
+                        multiline
+                        minRows={3}
+                    />
+                    {seedId && <div>当前种子ID: {seedId}</div>}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>关闭</Button>
+                <Button onClick={handleCreateSeed} variant="outlined">
+                    新建种子
+                </Button>
+                <Button
+                    onClick={handleExpand}
+                    variant="contained"
+                    disabled={seedId == null}
+                >
+                    更新并扩展
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+


### PR DESCRIPTION
## Summary
- add PromptDialog component allowing creating seeds and submitting prompts
- add GPT/GNN service selectors and prompt dialog trigger in ControlPanel
- remove manual node and auto expand controls
- allow all origins for backend CORS

## Testing
- `python -m pytest` (0 tests)
- `npm test --prefix web` (fails: Missing script "test")
- `npm run lint --prefix web` (fails: `next` not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad6191f964832e9e82c88a4ea1ebe2