### PR TITLE
feat: enhance graph layout and configuration

### DIFF
--- a/web/components/graph/ControlPanel.tsx
+++ b/web/components/graph/ControlPanel.tsx
@@ -4,21 +4,22 @@ import {
     Button,
     Stack,
     IconButton,
-    Tooltip,
     Box,
     Drawer,
     FormControl,
     InputLabel,
     Select,
     MenuItem,
+    TextField,
+    FormHelperText,
 } from '@mui/material'
-import SettingsIcon from '@mui/icons-material/Settings'
 import { useState } from 'react'
 import {useMediaQuery, useTheme} from "@mui/system";
 import {MenuIcon} from "lucide-react";
 import ConfigDrawer from "./ConfigDrawer";
 import {useGraphStore} from "@/lib/graphStore";
 import PromptDialog from "./PromptDialog";
+import {useServiceConfigStore} from "@/lib/serviceConfigStore";
 
 export default function ControlPanel() {
     const theme = useTheme()
@@ -28,8 +29,16 @@ export default function ControlPanel() {
     const { reset } = useGraphStore()
 
     const [promptOpen, setPromptOpen] = useState(false)
-    const [gptService, setGptService] = useState('default')
-    const [gnnService, setGnnService] = useState('default')
+    const {
+        gptService,
+        gptEndpoint,
+        gnnService,
+        gnnEndpoint,
+        setGptService,
+        setGptEndpoint,
+        setGnnService,
+        setGnnEndpoint,
+    } = useServiceConfigStore()
 
     // Drawer 控制
     const [drawerOpen, setDrawerOpen] = useState(false)
@@ -62,9 +71,20 @@ export default function ControlPanel() {
                                             onChange={(e) => setGptService(e.target.value)}
                                         >
                                             <MenuItem value="default">默认</MenuItem>
-                                            <MenuItem value="gpt-4">GPT-4</MenuItem>
+                                            <MenuItem value="custom">自定义</MenuItem>
                                         </Select>
+                                        <FormHelperText>支持配置远程 GPT 推理地址</FormHelperText>
                                     </FormControl>
+                                    <TextField
+                                        label="GPT 服务地址"
+                                        value={gptEndpoint}
+                                        onChange={(e) => setGptEndpoint(e.target.value)}
+                                        size="small"
+                                        fullWidth
+                                        placeholder="https://your-gpt-service/api"
+                                        sx={{ mt: 1 }}
+                                        disabled={gptService !== 'custom'}
+                                    />
                                     <FormControl fullWidth>
                                         <InputLabel>GNN 服务</InputLabel>
                                         <Select
@@ -73,9 +93,20 @@ export default function ControlPanel() {
                                             onChange={(e) => setGnnService(e.target.value)}
                                         >
                                             <MenuItem value="default">默认</MenuItem>
-                                            <MenuItem value="gnn-advanced">高级</MenuItem>
+                                            <MenuItem value="custom">自定义</MenuItem>
                                         </Select>
+                                        <FormHelperText>允许连接自托管的图网络服务</FormHelperText>
                                     </FormControl>
+                                    <TextField
+                                        label="GNN 服务地址"
+                                        value={gnnEndpoint}
+                                        onChange={(e) => setGnnEndpoint(e.target.value)}
+                                        size="small"
+                                        fullWidth
+                                        placeholder="https://your-gnn-service/api"
+                                        sx={{ mt: 1 }}
+                                        disabled={gnnService !== 'custom'}
+                                    />
                                     <Button variant="contained" fullWidth onClick={() => setPromptOpen(true)}>
                                         打开提示词
                                     </Button>
@@ -94,7 +125,7 @@ export default function ControlPanel() {
                         justifyContent="center"
                         sx={{ mb: 2, flexWrap: 'wrap' }}
                     >
-                        <FormControl sx={{ minWidth: 120 }} size="small">
+                        <FormControl sx={{ minWidth: 160 }} size="small">
                             <InputLabel>GPT 服务选项</InputLabel>
                             <Select
                                 value={gptService}
@@ -102,10 +133,19 @@ export default function ControlPanel() {
                                 onChange={(e) => setGptService(e.target.value)}
                             >
                                 <MenuItem value="default">TGT-TextGeneration</MenuItem>
-                                <MenuItem value="gpt-4">自定义</MenuItem>
+                                <MenuItem value="custom">自定义</MenuItem>
                             </Select>
                         </FormControl>
-                        <FormControl sx={{ minWidth: 120 }} size="small">
+                        <TextField
+                            label="GPT 服务地址"
+                            value={gptEndpoint}
+                            onChange={(e) => setGptEndpoint(e.target.value)}
+                            size="small"
+                            sx={{ minWidth: 200 }}
+                            placeholder="https://your-gpt-service/api"
+                            disabled={gptService !== 'custom'}
+                        />
+                        <FormControl sx={{ minWidth: 160 }} size="small">
                             <InputLabel>GNN 服务选项</InputLabel>
                             <Select
                                 value={gnnService}
@@ -113,9 +153,18 @@ export default function ControlPanel() {
                                 onChange={(e) => setGnnService(e.target.value)}
                             >
                                 <MenuItem value="default">TGT-Text2Graph</MenuItem>
-                                <MenuItem value="gnn-advanced">Microsoft Graphormer</MenuItem>
+                                <MenuItem value="custom">自定义</MenuItem>
                             </Select>
                         </FormControl>
+                        <TextField
+                            label="GNN 服务地址"
+                            value={gnnEndpoint}
+                            onChange={(e) => setGnnEndpoint(e.target.value)}
+                            size="small"
+                            sx={{ minWidth: 200 }}
+                            placeholder="https://your-gnn-service/api"
+                            disabled={gnnService !== 'custom'}
+                        />
                         <Button variant="contained" onClick={() => setPromptOpen(true)}>
                             打开提示词
                         </Button>

--- a/web/components/graph/ExpandOptionsPopover.tsx
+++ b/web/components/graph/ExpandOptionsPopover.tsx
@@ -1,19 +1,41 @@
 'use client'
 
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useEffect, useMemo, useState } from 'react'
 import { Node } from 'reactflow'
-import { Button, Paper, Typography, Stack } from '@mui/material'
+import { Button, Paper, Typography, Stack, TextField, Divider } from '@mui/material'
 
 type ExpandOptionsPopoverProps = {
     node: Node
     position: { x: number; y: number }
-    onExpand: (type: 'related' | 'deep' | 'new') => void
+    onExpand: (payload: { type: 'related' | 'deep' | 'new'; prompt?: string; title?: string }) => void
+    onMagnify: (nodeId: string) => void
+    hasExpandedSeed: boolean
+    isLeaf: boolean
     onClose: () => void
 }
 
 // ⬇️ forwardRef 用于接收 ref，从父组件注入
 const ExpandOptionsPopover = forwardRef<HTMLDivElement, ExpandOptionsPopoverProps>(
-    ({ node, position, onExpand, onClose }, ref) => {
+    ({ node, position, onExpand, onMagnify, hasExpandedSeed, isLeaf, onClose }, ref) => {
+        const isSeed = node.data?.role === 'seed'
+        const [title, setTitle] = useState(() => (typeof node.data?.title === 'string' ? node.data.title : ''))
+        const [prompt, setPrompt] = useState(() => (typeof node.data?.prompt === 'string' ? node.data.prompt : ''))
+
+        useEffect(() => {
+            setTitle(typeof node.data?.title === 'string' ? node.data.title : '')
+            setPrompt(typeof node.data?.prompt === 'string' ? node.data.prompt : '')
+        }, [node])
+
+        const canExpand = useMemo(() => prompt.trim().length > 0, [prompt])
+
+        const handleExpand = (type: 'related' | 'deep' | 'new') => {
+            onExpand({
+                type,
+                prompt,
+                title: isSeed ? title : undefined,
+            })
+        }
+
         return (
             <Paper
                 ref={ref}
@@ -32,14 +54,57 @@ const ExpandOptionsPopover = forwardRef<HTMLDivElement, ExpandOptionsPopoverProp
                 <Typography fontWeight="bold" gutterBottom>
                     展开 {node.data?.title || ''}
                 </Typography>
+                {isSeed && (
+                    <TextField
+                        fullWidth
+                        size="small"
+                        label="种子标题"
+                        value={title}
+                        onChange={(event) => setTitle(event.target.value)}
+                        sx={{ mb: 1.5 }}
+                    />
+                )}
+                <TextField
+                    fullWidth
+                    size="small"
+                    label={isSeed ? '提示词（用于第一次扩展）' : '提示词'}
+                    value={prompt}
+                    onChange={(event) => setPrompt(event.target.value)}
+                    multiline
+                    minRows={2}
+                    sx={{ mb: 1.5 }}
+                />
+                {hasExpandedSeed && isLeaf && (
+                    <Button
+                        variant="contained"
+                        color={node.data?.magnified ? 'secondary' : 'primary'}
+                        onClick={() => onMagnify(node.id)}
+                        sx={{ mb: 1.5 }}
+                    >
+                        {node.data?.magnified ? '还原卡片' : '放大查看'}
+                    </Button>
+                )}
+                <Divider sx={{ mb: 1.5 }} />
                 <Stack direction="column" spacing={1}>
-                    <Button variant="outlined" onClick={() => onExpand('related')}>
+                    <Button
+                        variant="outlined"
+                        onClick={() => handleExpand('related')}
+                        disabled={!canExpand}
+                    >
                         🔗 关联扩展
                     </Button>
-                    <Button variant="outlined" onClick={() => onExpand('deep')}>
+                    <Button
+                        variant="outlined"
+                        onClick={() => handleExpand('deep')}
+                        disabled={!canExpand}
+                    >
                         📚 深入展开
                     </Button>
-                    <Button variant="outlined" onClick={() => onExpand('new')}>
+                    <Button
+                        variant="outlined"
+                        onClick={() => handleExpand('new')}
+                        disabled={!canExpand}
+                    >
                         🌱 新想法
                     </Button>
                     <Button color="inherit" size="small" onClick={onClose}>

--- a/web/components/graph/GraphCanvas.tsx
+++ b/web/components/graph/GraphCanvas.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, {useCallback, useEffect, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import ReactFlow, {
     Controls,
     MiniMap,
@@ -19,6 +19,138 @@ import {useGraphStore} from "@/lib/graphStore";
 import {nodeTypes} from "@/types/ThoughtNode";
 import ExpandOptionsPopover from "@/components/graph/ExpandOptionsPopover";
 
+const VERTICAL_SPACING = 220
+const HORIZONTAL_SPACING = 260
+const AUTO_PROMPT_FALLBACK = '系统自动扩展'
+const MOCK_SUMMARIES = [
+    '系统自动扩展的内容',
+    '与当前主题高度关联的概念',
+    '可能的新领域方向探索',
+    '基于上下文的深度联想',
+    '推演出的潜在逻辑分支',
+    '抽象出的关联元素',
+    '来自AI的启发式推理',
+]
+
+type ExpandActionType = 'related' | 'deep' | 'new'
+
+type ExpandActionPayload = {
+    type: ExpandActionType
+    prompt?: string
+    title?: string
+}
+
+type NodeWithDepth = Node & { data: Node['data'] & { depth?: number; order?: number | string } }
+
+const resolveOrder = (node: NodeWithDepth) => {
+    const rawOrder = node.data?.order
+    if (typeof rawOrder === 'number') return rawOrder
+    if (typeof rawOrder === 'string') {
+        const parsed = Number(rawOrder)
+        return Number.isFinite(parsed) ? parsed : 0
+    }
+    return 0
+}
+
+const repositionNodes = (inputNodes: Node[], inputEdges: Edge[]): Node[] => {
+    if (!inputNodes.length) return inputNodes
+
+    const nodesById = new Map(inputNodes.map((node) => [node.id, node]))
+    const childrenByParent = new Map<string, string[]>()
+    const parentByChild = new Map<string, string>()
+
+    inputEdges.forEach((edge) => {
+        parentByChild.set(edge.target, edge.source)
+        const existing = childrenByParent.get(edge.source) ?? []
+        childrenByParent.set(edge.source, [...existing, edge.target])
+    })
+
+    const arranged = new Map<string, Node>()
+    const visited = new Set<string>()
+
+    const placeNode = (nodeId: string, depth: number) => {
+        if (visited.has(nodeId)) return
+        visited.add(nodeId)
+
+        const node = nodesById.get(nodeId) as NodeWithDepth | undefined
+        if (!node) return
+
+        const parentId = parentByChild.get(nodeId)
+        let position = node.position
+
+        if (parentId) {
+            const parentNode = (arranged.get(parentId) as NodeWithDepth | undefined) ?? (nodesById.get(parentId) as NodeWithDepth | undefined)
+            if (parentNode) {
+                const siblings = childrenByParent.get(parentId) ?? []
+                const index = siblings.indexOf(nodeId)
+                const offset = (index - (siblings.length - 1) / 2) * HORIZONTAL_SPACING
+                position = {
+                    x: parentNode.position.x + offset,
+                    y: parentNode.position.y + VERTICAL_SPACING,
+                }
+            }
+        } else {
+            position = {
+                x: node.position.x,
+                y: node.position.y,
+            }
+        }
+
+        const depthValue = depth < 0 ? 0 : depth
+        const orderValue = resolveOrder(node)
+        const zIndex = orderValue || depthValue + 1
+
+        const updatedNode: Node = {
+            ...node,
+            position,
+            draggable: false,
+            selectable: true,
+            data: {
+                ...node.data,
+                depth: depthValue,
+            },
+            style: {
+                ...node.style,
+                zIndex,
+            },
+        }
+
+        arranged.set(nodeId, updatedNode)
+
+        const children = childrenByParent.get(nodeId) ?? []
+        children.forEach((childId) => placeNode(childId, depthValue + 1))
+    }
+
+    const rootCandidates = inputNodes.filter((node) => !parentByChild.has(node.id))
+    if (rootCandidates.length === 0 && inputNodes.length > 0) {
+        placeNode(inputNodes[0].id, 0)
+    } else {
+        rootCandidates.forEach((root) => placeNode(root.id, 0))
+    }
+
+    inputNodes.forEach((node) => {
+        if (!arranged.has(node.id)) {
+            const depthValue = typeof node.data?.depth === 'number' ? node.data.depth : 0
+            const orderValue = resolveOrder(node as NodeWithDepth)
+            arranged.set(node.id, {
+                ...node,
+                draggable: false,
+                selectable: true,
+                data: {
+                    ...node.data,
+                    depth: depthValue,
+                },
+                style: {
+                    ...node.style,
+                    zIndex: orderValue || depthValue + 1,
+                },
+            })
+        }
+    })
+
+    return Array.from(arranged.values())
+}
+
 export default function GraphCanvas() {
     const {
         nodes: storeNodes,
@@ -35,44 +167,130 @@ export default function GraphCanvas() {
     const [selectedNode, setSelectedNode] = useState<Node | null>(null)
     const [popoverPosition, setPopoverPosition] = useState<{ x: number; y: number } | null>(null)
     const popoverRef = useRef<HTMLDivElement | null>(null)
+    const [hasExpandedSeed, setHasExpandedSeed] = useState(false)
     const MAX_NODE_COUNT = 100
-    const mockSummaries = [
-        '系统自动扩展的内容',
-        '与当前主题高度关联的概念',
-        '可能的新领域方向探索',
-        '基于上下文的深度联想',
-        '推演出的潜在逻辑分支',
-        '抽象出的关联元素',
-        '来自AI的启发式推理',
-    ]
-
     const theme = useTheme()
     const isDark = theme.palette.mode === 'dark'
 
-
-
-    function getRandomExpandType(): 'related' | 'deep' | 'new' {
-        const types = ['related', 'deep', 'new']
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
+    const getRandomExpandType = useCallback((): ExpandActionType => {
+        const types: ExpandActionType[] = ['related', 'deep', 'new']
         return types[Math.floor(Math.random() * types.length)]
-    }
+    }, [])
 
-    useEffect(() => {
-        console.log('🧠 当前节点总数：', nodes.length)
-    }, [nodes])
+    const handleExpandOption = useCallback(
+        (option: ExpandActionType | ExpandActionPayload) => {
+            if (nodes.length >= MAX_NODE_COUNT) {
+                console.warn('🌪️ 节点数量达到上限，停止自动扩展')
+                return
+            }
+
+            if (!selectedNode) return
+
+            const payload: ExpandActionPayload =
+                typeof option === 'string' ? { type: option } : option
+
+            const normalizedPrompt = (payload.prompt ?? '').trim() ||
+                (typeof selectedNode.data?.prompt === 'string' && selectedNode.data.prompt
+                    ? selectedNode.data.prompt
+                    : AUTO_PROMPT_FALLBACK)
+
+            const updatedTitle = payload.title?.trim()
+
+            const newId = `${selectedNode.id}-${Date.now()}`
+
+            const newNode: Node = {
+                id: newId,
+                type: 'thought',
+                position: {
+                    x: selectedNode.position.x,
+                    y: selectedNode.position.y + VERTICAL_SPACING,
+                },
+                data: {
+                    title:
+                        payload.type === 'new'
+                            ? '新想法'
+                            : payload.type === 'deep'
+                            ? '深入扩展'
+                            : '关联概念',
+                    description: MOCK_SUMMARIES[Math.floor(Math.random() * MOCK_SUMMARIES.length)],
+                    node_metadata: { tags: [payload.type] },
+                    highlight: false,
+                    depth: (selectedNode.data?.depth ?? 0) + 1,
+                    prompt: '',
+                    order: Date.now(),
+                    magnified: false,
+                },
+                draggable: false,
+            }
+
+            const newEdge: Edge = {
+                id: `${selectedNode.id}-${newId}`,
+                source: selectedNode.id,
+                target: newId,
+                type: 'default',
+            }
+
+            const updatedEdges = [...edges, newEdge]
+
+            const parentUpdatedNodes = nodes.map((node) => {
+                if (node.id === selectedNode.id) {
+                    return {
+                        ...node,
+                        draggable: false,
+                        data: {
+                            ...node.data,
+                            title: updatedTitle || node.data?.title,
+                            prompt: normalizedPrompt,
+                            highlight: true,
+                            magnified: false,
+                        },
+                    }
+                }
+                return {
+                    ...node,
+                    draggable: false,
+                    data: {
+                        ...node.data,
+                        highlight: node.id === 'root' || node.id === selectedNode.id,
+                        magnified: false,
+                    },
+                }
+            })
+
+            const nodesWithNew = [...parentUpdatedNodes, newNode]
+            const repositionedNodes = repositionNodes(nodesWithNew, updatedEdges)
+
+            setNodes(repositionedNodes)
+            setStoreNodes(() => repositionedNodes)
+            setEdges(updatedEdges)
+            addEdgeToStore(newEdge)
+
+            setSelectedNode(null)
+            setPopoverPosition(null)
+
+            if (selectedNode.data?.role === 'seed' && !hasExpandedSeed) {
+                setHasExpandedSeed(true)
+            }
+        },
+        [addEdgeToStore, edges, hasExpandedSeed, nodes, selectedNode, setEdges, setNodes, setStoreNodes],
+    )
 
     useEffect(() => {
         if (!selectedNode) return
-
-        if (growMode === 'manual') return // manual 模式不自动增长
+        if (growMode === 'manual') return
 
         const interval = setInterval(() => {
-            handleExpandOption(getRandomExpandType())
+            handleExpandOption({
+                type: getRandomExpandType(),
+                prompt:
+                    typeof selectedNode.data?.prompt === 'string' && selectedNode.data.prompt
+                        ? selectedNode.data.prompt
+                        : AUTO_PROMPT_FALLBACK,
+            })
         }, growMode === 'fury' ? 200 : 1500)
 
         return () => clearInterval(interval)
-    }, [growMode, selectedNode])
+    }, [getRandomExpandType, growMode, handleExpandOption, selectedNode])
 
     useEffect(() => {
         function handleClickOutside(event: MouseEvent) {
@@ -92,7 +310,6 @@ export default function GraphCanvas() {
         }
     }, [])
 
-    // 初始化根节点
     useEffect(() => {
         if (!initialized && storeNodes.length === 0) {
             setStoreNodes(() => [
@@ -100,22 +317,43 @@ export default function GraphCanvas() {
                     id: 'root',
                     type: 'thought',
                     position: { x: 300, y: 150 },
+                    draggable: false,
                     data: {
                         title: '种子',
                         description: '一切从一个想法开始。',
                         node_metadata: { tags: ['开心', '兴奋'] },
                         highlight: true,
-                        role: 'seed'
+                        role: 'seed',
+                        depth: 0,
+                        prompt: '',
+                        order: 0,
+                        magnified: false,
                     },
                 },
             ])
             setInitialized(true)
         }
-    }, [initialized, storeNodes.length, setStoreNodes])
+    }, [initialized, setStoreNodes, storeNodes.length])
 
-    // 同步 zustand 状态
-    useEffect(() => setNodes(storeNodes), [setNodes, storeNodes])
+    useEffect(() => {
+        const locked = storeNodes.map((node) => ({
+            ...node,
+            draggable: false,
+        }))
+        setNodes(repositionNodes(locked, storeEdges))
+    }, [setNodes, storeEdges, storeNodes])
+
     useEffect(() => setEdges(storeEdges), [setEdges, storeEdges])
+
+    useEffect(() => {
+        if (hasExpandedSeed) return
+        const seedIds = nodes.filter((node) => node.data?.role === 'seed').map((node) => node.id)
+        if (!seedIds.length) return
+        const seedHasChildren = edges.some((edge) => seedIds.includes(edge.source))
+        if (seedHasChildren) {
+            setHasExpandedSeed(true)
+        }
+    }, [edges, nodes, hasExpandedSeed])
 
     const onConnect = useCallback(
         (connection: Connection) => {
@@ -135,16 +373,17 @@ export default function GraphCanvas() {
             setEdges((eds) => addEdge(newEdge, eds))
             addEdgeToStore(newEdge)
         },
-        [setEdges, addEdgeToStore]
+        [addEdgeToStore, setEdges],
     )
 
-
-    // 点击节点
     const onNodeClick = useCallback(
         (event: React.MouseEvent, clickedNode: Node) => {
-            setSelectedNode(clickedNode)
+            const latestNode = nodes.find((node) => node.id === clickedNode.id) ?? clickedNode
+            setSelectedNode(latestNode)
 
-            if (growMode !== 'manual') return // 非手动模式不弹出 Popover
+            if (growMode !== 'manual' && !hasExpandedSeed) {
+                return
+            }
 
             const rect = (event.target as HTMLElement).getBoundingClientRect()
             setPopoverPosition({
@@ -152,71 +391,49 @@ export default function GraphCanvas() {
                 y: rect.top,
             })
 
-            // 高亮父节点
-            const parentEdge = edges.find((e) => e.target === clickedNode.id)
+            const parentEdge = edges.find((edge) => edge.target === latestNode.id)
             const parentId = parentEdge?.source
-            setNodes((nds) =>
-                nds.map((node) => ({
-                    ...node,
-                    data: {
-                        ...node.data,
-                        highlight: node.id === parentId || node.id === 'root',
-                    },
-                }))
-            )
+            const highlighted = nodes.map((node) => ({
+                ...node,
+                data: {
+                    ...node.data,
+                    highlight: node.id === parentId || node.id === 'root',
+                },
+            }))
+            setNodes(highlighted)
+            setStoreNodes(() => highlighted)
         },
-        [edges, setNodes, growMode]
+        [edges, growMode, hasExpandedSeed, nodes, setNodes, setStoreNodes],
     )
 
+    const handleMagnify = useCallback(
+        (nodeId: string) => {
+            const toggled = nodes.map((node) => ({
+                ...node,
+                data: {
+                    ...node.data,
+                    magnified: node.id === nodeId ? !node.data?.magnified : false,
+                },
+            }))
+            setNodes(toggled)
+            setStoreNodes(() => toggled)
 
-    const handleExpandOption = (type: 'related' | 'deep' | 'new') => {
-        if (nodes.length >= MAX_NODE_COUNT) {
-            console.warn('🌪️ 节点数量达到上限，停止自动扩展')
-            return
-        }
+            if (selectedNode?.id === nodeId) {
+                const latest = toggled.find((node) => node.id === nodeId) ?? null
+                setSelectedNode(latest)
+            }
+        },
+        [nodes, selectedNode, setNodes, setStoreNodes],
+    )
 
-        if (!selectedNode) return
-
-
-        const newId = `${selectedNode.id}-${Date.now()}`
-
-        const baseAngle = Math.random() * Math.PI * 2 // 随机初始角度
-        const radius = 200
-        const offsetAngle = (Math.random() - 0.5) * 0.5
-
-        const angle = baseAngle + offsetAngle
-        const newX = selectedNode.position.x + Math.cos(angle) * radius
-        const newY = selectedNode.position.y + Math.sin(angle) * radius
-
-        const newNode: Node = {
-            id: newId,
-            type: 'thought',
-            position: { x: newX, y: newY },
-            data: {
-                title: type === 'new' ? '新想法' : type === 'deep' ? '深入扩展' : '关联概念',
-                description: mockSummaries[Math.floor(Math.random() * mockSummaries.length)],
-                node_metadata: { tags: [type] },
-                highlight: false,
-            },
-        }
-
-        const newEdge: Edge = {
-            id: `${selectedNode.id}-${newId}`,
-            source: selectedNode.id,
-            target: newId,
-            type: 'default',
-        }
-
-        setNodes((nds) => [...nds, newNode])
-        setEdges((eds) => [...eds, newEdge])
-        setSelectedNode(null)
-        setPopoverPosition(null)
-    }
-
+    const selectedNodeIsLeaf = useMemo(
+        () => (selectedNode ? !edges.some((edge) => edge.source === selectedNode.id) : false),
+        [edges, selectedNode],
+    )
 
     return (
         <div
-            style={{ height: '100vh', width: '100vw' ,position: 'relative'}}
+            style={{ height: '100vh', width: '100vw', position: 'relative' }}
             className={isDark ? 'dark-flow' : ''}
         >
             <Typography
@@ -233,7 +450,7 @@ export default function GraphCanvas() {
                     zIndex: 1000,
                 }}
             >
-            当前模式：{growMode === 'manual' ? '手动模式' : growMode === 'free' ? '自由模式' : '狂暴模式'}
+                当前模式：{growMode === 'manual' ? '手动模式' : growMode === 'free' ? '自由模式' : '狂暴模式'}
             </Typography>
 
             <ReactFlow
@@ -247,17 +464,21 @@ export default function GraphCanvas() {
                 fitView
                 panOnDrag
                 zoomOnScroll
+                nodesDraggable={false}
             >
                 <MiniMap />
                 <Controls />
             </ReactFlow>
 
-            {growMode === 'manual' && selectedNode && popoverPosition && (
+            {selectedNode && popoverPosition && (
                 <ExpandOptionsPopover
                     ref={popoverRef}
                     node={selectedNode}
                     position={popoverPosition}
                     onExpand={handleExpandOption}
+                    onMagnify={handleMagnify}
+                    hasExpandedSeed={hasExpandedSeed}
+                    isLeaf={selectedNodeIsLeaf}
                     onClose={() => {
                         setSelectedNode(null)
                         setPopoverPosition(null)

--- a/web/components/graph/ThoughtCard.tsx
+++ b/web/components/graph/ThoughtCard.tsx
@@ -7,14 +7,15 @@ import styles from '../../styles/Grow.module.css'
 
 export default function ThoughtCard({ data }: NodeProps) {
     const highlight = !!data?.highlight
+    const magnified = !!data?.magnified
 
     return (
         <motion.div
             initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            whileHover={{ scale: 1.03 }}
+            animate={{ scale: magnified ? 1.08 : 1, opacity: 1 }}
+            whileHover={{ scale: magnified ? 1.1 : 1.03 }}
             transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-            className={`${styles.card} ${highlight ? styles.highlighted : styles.default}`}
+            className={`${styles.card} ${highlight ? styles.highlighted : styles.default} ${magnified ? styles.magnified : ''}`}
         >
             <div className={styles.title}>{data.title || '无标题'}</div>
 
@@ -30,6 +31,8 @@ export default function ThoughtCard({ data }: NodeProps) {
 
             <Handle type="target" position={Position.Top} className={styles.handle} />
             <Handle type="source" position={Position.Bottom} className={styles.handle} />
+            <Handle type="target" position={Position.Left} className={styles.handle} />
+            <Handle type="source" position={Position.Right} className={styles.handle} />
         </motion.div>
     )
 }

--- a/web/lib/graphStore.ts
+++ b/web/lib/graphStore.ts
@@ -6,12 +6,17 @@ const initialRootNode: Node = {
     id: 'root',
     type: 'thought',
     position: { x: 300, y: 150 },
+    draggable: false,
     data: {
         title: '种子',
         description: '一切从一个想法开始。',
         node_metadata: { tags: ['AI', '思维链'] },
         highlight: true,
         role: 'seed',
+        depth: 0,
+        prompt: '',
+        order: 0,
+        magnified: false,
     },
 }
 

--- a/web/lib/serviceConfigStore.ts
+++ b/web/lib/serviceConfigStore.ts
@@ -1,0 +1,51 @@
+import {create} from 'zustand'
+import {persist, createJSONStorage} from 'zustand/middleware'
+
+type ServiceConfigState = {
+    gptService: string
+    gptEndpoint: string
+    gnnService: string
+    gnnEndpoint: string
+    setGptService: (service: string) => void
+    setGptEndpoint: (endpoint: string) => void
+    setGnnService: (service: string) => void
+    setGnnEndpoint: (endpoint: string) => void
+}
+
+const defaultState = {
+    gptService: 'default',
+    gptEndpoint: '',
+    gnnService: 'default',
+    gnnEndpoint: '',
+}
+
+export const useServiceConfigStore = create<ServiceConfigState>()(
+    persist(
+        (set) => ({
+            ...defaultState,
+            setGptService: (service) => set((state) => ({
+                gptService: service,
+                // 当切换服务选项时保留已配置的地址，除非改为默认
+                gptEndpoint: service === 'default' ? '' : state.gptEndpoint,
+            })),
+            setGptEndpoint: (endpoint) => set(() => ({ gptEndpoint: endpoint })),
+            setGnnService: (service) => set((state) => ({
+                gnnService: service,
+                gnnEndpoint: service === 'default' ? '' : state.gnnEndpoint,
+            })),
+            setGnnEndpoint: (endpoint) => set(() => ({ gnnEndpoint: endpoint })),
+        }),
+        {
+            name: 'service-config',
+            storage: typeof window === 'undefined'
+                ? undefined
+                : createJSONStorage(() => localStorage),
+            partialize: (state) => ({
+                gptService: state.gptService,
+                gptEndpoint: state.gptEndpoint,
+                gnnService: state.gnnService,
+                gnnEndpoint: state.gnnEndpoint,
+            }),
+        },
+    ),
+)

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/styles/Grow.module.css
+++ b/web/styles/Grow.module.css
@@ -159,6 +159,11 @@
     border-color: #22c55e; /* green-500 */
 }
 
+.magnified {
+    box-shadow: 0 18px 36px rgba(34, 197, 94, 0.25);
+    border-color: #15803d;
+}
+
 .title {
     font-size: 1.125rem;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- lock thought nodes in place, apply tree-style repositioning to prevent overlap, and support magnification state on the canvas
- require prompts and optional title updates through the expand popover while offering magnify and structured expansion actions
- allow configuring remote GPT/GNN endpoints via a persisted service store and updated control panel selectors

## Testing
- npm run lint *(configuration prompt prevented automated run)*

------
https://chatgpt.com/codex/tasks/task_e_68ca78a3fcc4832e94278a00eaebc6ed